### PR TITLE
Add example structures to all endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -70,6 +70,14 @@ Note: You can access this resource using the `id` or `name` as userId
 
 Returns the `User-Object`
 
+#### Example
+
+```json
+{
+  "user": { }
+}
+```
+
 #### Errors
 
 * UserNotFoundException


### PR DESCRIPTION
The documentation is missing the returned structure for a lot of endpoints.

For example the `/user` endpoint returns **not** just the User-Object, but an object containing it.

If there is any reason to not provide these examples just close this PR otherwise I would add examples to the rest of the endpoints.