### PR TITLE
fix double transaction revert

### DIFF
--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -11,6 +11,7 @@ use App\Exception\ArticleNotFoundException;
 use App\Exception\ParameterNotFoundException;
 use App\Exception\TransactionBoundaryException;
 use App\Exception\TransactionInvalidException;
+use App\Exception\TransactionNotDeletableException;
 use App\Exception\TransactionNotFoundException;
 use App\Exception\UserNotFoundException;
 use Doctrine\DBAL\LockMode;

--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -155,6 +155,10 @@ class TransactionService {
                 throw new TransactionNotFoundException($transactionId);
             }
 
+            if ($transaction->isDeleted()) {
+                throw new TransactionNotDeletableException($transactionId);
+            }
+
             $article = $transaction->getArticle();
             if ($article) {
                 $article->decrementUsageCount();


### PR DESCRIPTION
There was absolutely no validation in place preventing a transaction from getting reverted multiple times. It was solely up to the frontend not to do this. We have run into this in our deployment multiple times when the frontend didn't work as expected due to network issues.

After a couple of years in deployment we have corruption issues for 96 of 109 user that are presumably mostly caused by this :sweat_smile: 